### PR TITLE
Fix error in write_multiple_registers

### DIFF
--- a/modbus_tcp_server/processor.py
+++ b/modbus_tcp_server/processor.py
@@ -54,7 +54,8 @@ def write_single_register(db: BaseDataSource, unit_id: int, address: int, value:
 
 
 def write_multiple_registers(db: BaseDataSource, unit_id: int, msg: MODBUSTCPMessage) -> bytes:
-    address, amount, databytes, reg_data = STRUCT_HHB.unpack(msg.data[1:6]), msg.data[6:]
+    address, amount, databytes = STRUCT_HHB.unpack(msg.data[1:6])
+    reg_data = msg.data[6:]
     if databytes != 2 * amount:
         raise InvalidFrame('Mismatch between writing amount and no of bytes')
 


### PR DESCRIPTION
Hello, thank you for this project, it's very useful.

I found a small problem with the `write_multiple_registers` function:

`STRUCT_HHB.unpack` returns a tuple , so the original code attempted to unpack only two values but expected 4, equivalent to this code:
```python
>>> a, b, c, d = (1, 2, 3), 4
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not enough values to unpack (expected 4, got 2)
```
<details><summary>Stacktrace</summary>

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "[...]\Lib\threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "[...]\site-packages\satella\coding\concurrent\thread.py", line 330, in run
    self.loop()
  File "[...]\site-packages\satella\coding\recast_exceptions.py", line 260, in inner
    v = fun(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^
  File "[...]\site-packages\modbus_tcp_server\network\conn_thread.py", line 53, in loop
    msg = self.server.process_message(packet)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[...]\site-packages\modbus_tcp_server\network\accept_thread.py", line 32, in process_message
    return self.processor.process(msg)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[...]\site-packages\modbus_tcp_server\processor.py", line 111, in process
    b = proc_fun(self.data_source, msg.unit_id, msg)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[...]\site-packages\modbus_tcp_server\processor.py", line 57, in write_multiple_registers
    address, amount, databytes, reg_data = STRUCT_HHB.unpack(msg.data[1:6]), msg.data[6:]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 4, got 2)
```
</details> 